### PR TITLE
Fix typo in heroImage.field in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ return [
         "image.template" => "assets/img/og-image-template.png", // path to your template image relative from your document root
         "title.position" => [300, 35], // x,y position of your text in pixel
         "title.charactersPerLine" => 30, // number of characters before a line break
-        "heroImage.field" => 'myHero, // fieldname of the hero image
+        "heroImage.field" => 'myHero', // fieldname of the hero image
         "heroImage.cropsize" => [738, 465], // size in pixels of the rendered hero image
         "heroImage.position" => [429, 287], // x,y position of the hero image on the template image
         "heroImage.fallbackColor" => [3, 105, 161], // r,g,b color to fill the hero-image area if no image given


### PR DESCRIPTION
Hi there Mauricie! Thank you for all the Kirby Plugins! I'm finally sitting down to install og-image and found this issue. Thought I'd try submitting a pull request to address it—a small typo in the .README.

It was missing a closing single quote for myhero example; was installing it and found the issue  when I was copying/pasting as I installed the lugin.