### PR TITLE
Round multiline $yPosition to get int

### DIFF
--- a/lib/page-methods.php
+++ b/lib/page-methods.php
@@ -149,7 +149,7 @@ return [
                 $xPosition = intval(($imageWidth -  $textWidth) / 2);
             }
 
-            imagettftext($canvas, $fontSize, 0, $xPosition, $yPosition + $y, $textColor, $font, $line);
+            imagettftext($canvas, $fontSize, 0, $xPosition, round($yPosition + $y), $textColor, $font, $line);
             $y += $fontSize * $fontLineHeight; // Increase the y position for the next line
         }
 


### PR DESCRIPTION
Solves the ”Implicit conversion from float NNN.N to int loses precision“ issue I’m getting when using `'font.lineheight' => 1.35` or similar value that wont generate int on multiline. 